### PR TITLE
Add snapshot support to config-file.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,9 @@ class influxdb (
   $admin_https_enabled            = $influxdb::params::admin_https_enabled,
   $admin_https_certificate        = $influxdb::params::admin_https_certificate,
 
+  # Snapshot Section
+  $snapshot_enabled               = $influxdb::params::snapshot_enabled,
+
   # Graphite Section
   $graphite_enabled               = $influxdb::params::graphite_enabled,
   $graphite_bind_address          = $influxdb::params::graphite_bind_address,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,6 +89,9 @@ class influxdb::params {
   $admin_https_enabled = false
   $admin_https_certificate = '/etc/ssl/influxdb.pem'
 
+  # Snapshot Section
+  $snapshot_enabled = false
+
   # Graphite Section
   $graphite_enabled = false
   $graphite_bind_address = ':2003'

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -89,6 +89,14 @@ peers = [ <% meta_peers.each do |peer| -%> "<%= peer %>", <% end -%> ]
   https-enabled = <%= scope.lookupvar('influxdb::admin_https_enabled') %>
   https-certificate = "<%= scope.lookupvar('influxdb::admin_https_certificate') %>"
 
+###
+### [snapshot]
+###
+### Controls whether or not database snapshots are permitted
+###
+
+[snapshot]
+  enabled = <%= scope.lookupvar('influxdb::snapshot_enabled') %>
 
 ###
 ### [http]


### PR DESCRIPTION
Snapshot support is mentioned in the official documentation:

https://influxdb.com/docs/v0.9/administration/backup_and_restore.html

And the docs specify that enabling this feature is managed through a new config section.

```
[snapshot]
enabled = true
```

This PR adds snapshot support into this module. It can be enabled similarly to how graphite and collectd are enabled, through a `snapshot_enabled` parameter on the class. As per the documentation, the parameter defaults to false.

While the documentation does say that this is how the feature is configured, at this time (0.9.3 and 0.9.4) setting this to false does not prevent snapshots from being taken. I expect this will be fixed in future releases.

I've tested this live on my own systems, and setting this parameter does configure the snapshot as listed. Setting it to `false` and not declaring it are equivalent actions, as they should be.
