### PR TITLE
handle float as string issue in [data]

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -37,7 +37,7 @@
 
 [data]
 <% @data_section.sort_by{|key, value| key}.each do |key, value| %><%
-    if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float)
+    if ( value =~ /^[\d\.]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float)
   %>  <%= key %> = <%= value %><%
     else
   %>  <%= key %> = "<%= value %>"<% 


### PR DESCRIPTION
fixes an issue in puppet 3.8.x where the default value of
wal-compaction-threshold is handled as a string and thus quoted.
