### PR TITLE
Ensure file fix

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,7 +67,7 @@ class influxdb::config (
   }
 
   file { $::influxdb::config_file:
-    ensure  => file,
+    ensure  => present,
     owner   => $::influxdb::influxdb_user,
     group   => $::influxdb::influxdb_group,
     mode    => '0640',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,7 +67,7 @@ class influxdb::config (
   }
 
   file { $::influxdb::config_file:
-    ensure  => $::influxdb::package_ensure,
+    ensure  => file,
     owner   => $::influxdb::influxdb_user,
     group   => $::influxdb::influxdb_group,
     mode    => '0640',


### PR DESCRIPTION
Hello,

You used to have the package_version to set the version you want but I see this now became package_ensure. If you try for example package_ensure = '0.9.5.1',  below file resource fails.

It fails because possible values for ensure are present, absent, file, directory, and link. 

Cheers
