### PR TITLE
Pretty-print arrays for graphite templates.

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -124,8 +124,10 @@
 <% @graphites_section.sort_by{|key, value| key}.each do |key, graphite_section| %>
 [[graphite]]
 <% graphite_section.sort_by{|key, value| key}.each do |key, value| %><%
-  if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float) || value.is_a?(Array)
+  if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float)
   %>  <%= key %> = <%= value %><%
+  elsif value.is_a?(Array)
+  %>  <%= key %> = <%= value.inspect %><%
   else 
   %>  <%= key %> = "<%= value %>"<% 
   end %>


### PR DESCRIPTION
Hey Olivier,

No matter how I formatted my graphite templates, the way this was printing them out was breaking the syntax of the config file.  The "templates" parameter must be in array format (i.e. ['like', 'this']).

I just moved the `if value.is_a?(Array)` to an elsif, and added `.inspect` to `value`.  Tested and works for me.
