### PR TITLE
Retention policy of 0 and ruby 1.8.7 support

### DIFF
--- a/lib/puppet/provider/influxdb_database/ruby.rb
+++ b/lib/puppet/provider/influxdb_database/ruby.rb
@@ -16,9 +16,9 @@ Puppet::Type.type(:influxdb_database).provide(:ruby) do
     end
     databases = output.split("\n")[3..-1]
     databases.collect do |name|
-      new(:name    => name,
+      new({:name    => name,
         :ensure  => :present,
-      )
+      })
     end
   end
 

--- a/lib/puppet/provider/influxdb_retention_policy/ruby.rb
+++ b/lib/puppet/provider/influxdb_retention_policy/ruby.rb
@@ -21,7 +21,7 @@ commands :influx_cli => '/usr/bin/influx'
     databases = dbs.split("\n")[3..-1]
 
     databases.collect do |db|
-      begin 
+      begin
         output = influx_cli(['-execute', "show retention policies on #{db}"].compact)
       rescue Puppet::ExecutionFailure => e
         Puppet.debug("#show retention policies had an error -> #{e.inspect}")
@@ -89,7 +89,7 @@ commands :influx_cli => '/usr/bin/influx'
   end
 
   def self.duration_to_s(dur)
-    re = /^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?$/
+    re = /^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s?)?$/
     match = dur.match re
     if match
       val = 0

--- a/lib/puppet/type/influxdb_retention_policy.rb
+++ b/lib/puppet/type/influxdb_retention_policy.rb
@@ -21,7 +21,7 @@ Puppet::Type.newtype(:influxdb_retention_policy) do
   end
 
   def duration_to_s(dur)
-    re = /^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?$/
+    re = /^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s?)?$/
     match = dur.match re
     if match
       val = 0
@@ -49,7 +49,7 @@ Puppet::Type.newtype(:influxdb_retention_policy) do
     end
 
   end
- 
+
   newproperty(:replication) do
     desc "Number of replication"
     newvalues(/^\d+$/)

--- a/lib/puppet/type/influxdb_retention_policy.rb
+++ b/lib/puppet/type/influxdb_retention_policy.rb
@@ -35,12 +35,12 @@ Puppet::Type.newtype(:influxdb_retention_policy) do
     return nil
   end
 
-  newproperty(:database,) do
+  newproperty(:database) do
     desc "Database retention"
     newvalues(/^\S+$/)
   end
 
-  newproperty(:duration,) do
+  newproperty(:duration) do
     desc "Duration of retention, format is <INT>w<INT>d<INT>h<INT>s"
     newvalues(/^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?$/)
 
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:influxdb_retention_policy) do
 
   end
  
-  newproperty(:replication,) do
+  newproperty(:replication) do
     desc "Number of replication"
     newvalues(/^\d+$/)
   end


### PR DESCRIPTION
This pull request contains two fixes:
- support for ruby 1.8.7
- if the current retention policy is 0 seconds, then influxdb only output '0' and not '0s'. add support for this in the puppet module
