### PR TITLE
Add support for influxdb 1.0.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,8 +15,16 @@
 
 ##Overview
 
-The influxdb module lets you use Puppet to install, configure, and manage Influxdb version 0.10.x and 0.9.x
-The current InfluxDB version is 0.10
+The influxdb module lets you use Puppet to install, configure, and manage Influxdb version 1.0.0+
+The current InfluxDB version is 1.2.0
+
+## Deprecation Warning
+
+InfluxDB 1.0.0 contains [breaking changes](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md#v100-2016-09-08)
+which require changing the `data-logging-enabled` config attribute to `trace-logging-enabled`.
+The other configuration changes are managed by the `influxdb.conf.erb` template already.
+
+If you are using an older version of InfluxDB, you will need to use version 0.5.0 of this module
 
 ##Module Description
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,7 @@ class influxdb::params {
     wal-partition-flush-delay => '2s',
     wal-dir => '/var/lib/influxdb/wal',
     wal-logging-enabled => true,
-    data-logging-enabled => true,
+    trace-logging-enabled => true,
     wal-compaction-threshold => 0.5,
     wal-max-series-size => 1048576,
     wal-flush-cold-interval => '5s',

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -45,13 +45,13 @@
 <% end %>
 
 ###
-### [cluster]
+### [coordinator]
 ###
 ### Controls non-Raft cluster behavior, which generally includes how data is
 ### shared across shards.
 ###
 
-[cluster]
+[coordinator]
 <% @cluster_section.sort_by{|key, value| key}.each do |key, value| %><%
     if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float) || value.is_a?(Array)
   %>  <%= key %> = <%= value %><%
@@ -143,12 +143,12 @@
 <% end %>
 
 ###
-### [collectd]
+### [[collectd]]
 ###
 ### Controls the listener for collectd data.
 ###
 
-[collectd]
+[[collectd]]
 <% @collectd_section.sort_by{|key, value| key}.each do |key, value| %><%
     if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float) || value.is_a?(Array)
   %>  <%= key %> = <%= value %><%
@@ -158,12 +158,12 @@
 <% end %>
 
 ###
-### [opentsdb]
+### [[opentsdb]]
 ###
 ### Controls the listener for OpenTSDB data.
 ###
 
-[opentsdb]
+[[opentsdb]]
 <% @opentsdb_section.sort_by{|key, value| key}.each do |key, value| %><%
     if ( value =~ /^[\d]+$/ ) || value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Float) || value.is_a?(Array)
   %>  <%= key %> = <%= value %><%


### PR DESCRIPTION
InfluxDB 1.0.0 contains [breaking changes](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md#v100-2016-09-08) which require changing the `data-logging-enabled` config attribute to `trace-logging-enabled`. The other configuration changes in the `influxdb.conf.erb` template.