### PR TITLE
Install influxdb-client alongside the main package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class influxdb::install
 {
 	$packages = [
 		'influxdb',
-		'influxdb-client'
+		'influxdb-client',
 	]
 
   package { $packages :

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,12 @@
 #
 class influxdb::install
 {
+	$packages = [
+		'influxdb',
+		'influxdb-client'
+	]
 
-  package {'influxdb':
+  package { $packages :
     ensure   => $::influxdb::package_ensure,
   }
 


### PR DESCRIPTION
This is required as the 'influx' CLI has been removed from the main package and moved to it's own. The influxdb_database and influxdb_retention_policy types do not work without this package present.