### PR TITLE
Update retention policy cli parsing to support influx v1.x

### DIFF
--- a/lib/puppet/provider/influxdb_retention_policy/ruby.rb
+++ b/lib/puppet/provider/influxdb_retention_policy/ruby.rb
@@ -29,7 +29,7 @@ commands :influx_cli => '/usr/bin/influx'
       end
       policies = output.split("\n")[1..-1]
       policies.each do |policy|
-        ret_name , duration , replica, is_default = policy.split("\t").reject { |e| e.to_s.empty? }
+        ret_name , duration , replica, is_default = policy.split(/\s+/).reject { |e| e.to_s.empty? }
         dur_s = self.duration_to_s(duration)
         instances << new(
            :name        => "#{ret_name}@#{db}",

--- a/lib/puppet/provider/influxdb_retention_policy/ruby.rb
+++ b/lib/puppet/provider/influxdb_retention_policy/ruby.rb
@@ -30,6 +30,10 @@ commands :influx_cli => '/usr/bin/influx'
       policies = output.split("\n")[1..-1]
       policies.each do |policy|
         ret_name , duration , replica, is_default = policy.split(/\s+/).reject { |e| e.to_s.empty? }
+        if ret_name.nil? || duration.nil?
+          Puppet.debug("failed to parse policy name and duration from #{policy}")
+          next
+        end
         dur_s = self.duration_to_s(duration)
         instances << new(
            :name        => "#{ret_name}@#{db}",

--- a/lib/puppet/provider/influxdb_retention_policy/ruby.rb
+++ b/lib/puppet/provider/influxdb_retention_policy/ruby.rb
@@ -70,7 +70,7 @@ commands :influx_cli => '/usr/bin/influx'
     end
     short_ret_name = "#{resource[:name]}".split('@').first
     if @property_flush[:ensure] == :present
-      if resource[:is_default]
+      if resource[:is_default] == 'true'
         influx_cli(['-execute', "create RETENTION POLICY \"#{short_ret_name}\" ON #{resource[:database]} DURATION #{resource[:duration]} REPLICATION #{resource[:replication]} DEFAULT"].compact)
       else
         influx_cli(['-execute', "create RETENTION POLICY \"#{short_ret_name}\" ON #{resource[:database]} DURATION #{resource[:duration]} REPLICATION #{resource[:replication]}"].compact)


### PR DESCRIPTION
The output of "show retention policies" changed with version 1.0 of influx. It now separates the fields with spaces instead of tabs, and there is an extra column. I've tested this update with 1.2.4 and it behaves correctly now and should still work the same with versions <1.

(Background: compare https://docs.influxdata.com/influxdb/v0.9/query_language/schema_exploration/#explore-retention-policies-with-show-retention-policies
and
https://docs.influxdata.com/influxdb/v1.0/query_language/schema_exploration/#explore-retention-policies-with-show-retention-policies) 