### PR TITLE
add dependency on ::repo for ::install if manage_repo is enabled

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,12 @@ class influxdb::install {
     }
   }
 
-  package { $packages :
-    ensure   => $::influxdb::package_ensure,
+  if $::influxdb::manage_repo {
+	ensure_packages($packages, {
+	  ensure    => $::influxdb::package_ensure,
+	  require   => Class['::influxdb::repo'],
+	})
+  } else {
+    ensure_packages($packages, {ensure => $::influxdb::package_ensure})
   }
 }


### PR DESCRIPTION
Add dependency on ::repo for ::install if manage_repo is enabled.  Otherwise ::install can be called before ::repo and installs the OS native package, which in case of Debian9 does not provide the influx client and thus causes influxdb_database and influxdb_retention_policy to fail until the next apt upgrade. Also moved to ensure_packages from already present stdlib dependency to declare resources more safely in case of duplicates in the catalog.