### PR TITLE
Fix non-determinsim in manifests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,10 @@ class influxdb (
   class { '::influxdb::service': } ->
   Class['::influxdb']
 
+  if $manage_repo {
+    Class['::influxdb::repo'] -> Class['::influxdb::install']
+  }
+
   create_resources(influxdb_database, $databases)
   create_resources(influxdb_retention_policy, $retention_policies)
 }


### PR DESCRIPTION
This commit avoids non-determism that appears in manifests.
Specifically, it adds a missing dependency between `repo` and `install`.

As motivating example consider the following two executions which invoke a different sequence of execution.

First run: The `influxdb` package is installed after `apt-get update`.
```
Warning: /Apt_key[influxdb]: The id should be a full fingerprint (40 characters), see README.
Notice: /Stage[main]/Apt/File[preferences]/ensure: created
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/ensure: defined content as '{md5}0962d70c4ec78bbfa6f3544ae0c41974'
Notice: /Stage[main]/Influxdb::Repo/Apt::Key[influxdb]/Apt_key[influxdb]/ensure: created
Notice: /Stage[main]/Influxdb::Repo/Package[apt-transport-https]/ensure: created
Notice: /Stage[main]/Influxdb::Repo/Apt::Source[influxdb]/Apt::Setting[list-influxdb]/File[/etc/apt/sources.list.d/influxdb.list]/ensure: defined content as '{md5}8de7d0d0cf0f3a3d9cc7d8119a21e8d3'
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Influxdb::Install/Package[influxdb]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/wal]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/hh]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/data]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/content: content changed '{md5}aa52e0fcf89c391f7c082ae3d3cf7fd0' to '{md5}d6d1d8d5c52ef773a95076f5519b4ff2'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/owner: owner changed 'root' to 'influxdb'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/group: group changed 'root' to 'influxdb'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/mode: mode changed '0644' to '0640'
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/meta]/ensure: created
Error: Could not start Service[influxdb]: Execution of '/usr/sbin/service influxdb start' returned 1: Starting influxdb...
influxdb process was unable to start [ FAILED ]
Error: /Stage[main]/Influxdb::Service/Service[influxdb]/ensure: change from stopped to running failed: Could not start Service[influxdb]: Execution of '/usr/sbin/service influxdb start' returned 1: Starting influxdb...
influxdb process was unable to start [ FAILED ]
Notice: /Stage[main]/Influxdb::Service/Service[influxdb]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 29.63 seconds
```

Second run: The `influxdb` package is installed before the `apt-get update`

```
Warning: /Apt_key[influxdb]: The id should be a full fingerprint (40 characters), see README.
Notice: /Stage[main]/Influxdb::Repo/Package[apt-transport-https]/ensure: created
Notice: /Stage[main]/Apt/File[preferences]/ensure: created
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/ensure: defined content as '{md5}0962d70c4ec78bbfa6f3544ae0c41974'
Notice: /Stage[main]/Influxdb::Install/Package[influxdb]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/meta]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/hh]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/content: content changed '{md5}81c5d3fd6327d28017edbf006b8b1a44' to '{md5}d6d1d8d5c52ef773a95076f5519b4ff2'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/owner: owner changed 'root' to 'influxdb'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/group: group changed 'root' to 'influxdb'
Notice: /Stage[main]/Influxdb::Config/File[/etc/influxdb/influxdb.conf]/mode: mode changed '0644' to '0640'
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/data]/ensure: created
Notice: /Stage[main]/Influxdb::Config/File[/var/lib/influxdb/wal]/ensure: created
Notice: /Stage[main]/Influxdb::Service/Service[influxdb]/ensure: ensure changed 'stopped' to 'running'
Notice: /Stage[main]/Influxdb::Repo/Apt::Key[influxdb]/Apt_key[influxdb]/ensure: created
Notice: /Stage[main]/Influxdb::Repo/Apt::Source[influxdb]/Apt::Setting[list-influxdb]/File[/etc/apt/sources.list.d/influxdb.list]/ensure: defined content as '{md5}8de7d0d0cf0f3a3d9cc7d8119a21e8d3'
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 16.10 seconds
```

